### PR TITLE
ci: add github workflow to test the projects

### DIFF
--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -47,3 +47,14 @@ jobs:
       - name: Run tests
         run: npm test
         working-directory: ${{ matrix.project }}
+
+      - name: Check formatting
+        run: |
+          # The `npm pkg get` command exits with 1 if the script is not found.
+          if [ "$(npm pkg get scripts.format:check)" != "{}" ]; then
+            echo "::notice title=Formatting Check::'format:check' script found in ${{ matrix.project }}. Running it."
+            npm run format:check
+          else
+            echo "::notice title=Formatting Check::'format:check' script not found in ${{ matrix.project }}. Skipping."
+          fi
+        working-directory: ${{ matrix.project }}

--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -1,0 +1,49 @@
+name: Test Node.js Projects
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  discover-projects:
+    runs-on: ubuntu-latest
+    outputs:
+      projects: ${{ steps.find-projects.outputs.projects }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: find-projects
+        name: Find Node.js projects
+        run: |
+          # Find all directories under `pipelines` that contain a package.json,
+          # then format the list as a JSON array for the matrix strategy.
+          PROJECTS=$(find pipelines -name package.json -exec dirname {} \; | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "projects=$PROJECTS" >> $GITHUB_OUTPUT
+
+  test:
+    needs: discover-projects
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ${{ fromJson(needs.discover-projects.outputs.projects) }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: "npm"
+          cache-dependency-path: "${{ matrix.project }}/package-lock.json"
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ${{ matrix.project }}
+
+      - name: Run tests
+        run: npm test
+        working-directory: ${{ matrix.project }}

--- a/pipelines/log-surge/package.json
+++ b/pipelines/log-surge/package.json
@@ -10,6 +10,7 @@
     "build:test": "./node_modules/.bin/esbuild src/main.ts --target=es2018 --bundle --outfile=dist/main.test.mjs --format=esm",
     "build:watch": "./node_modules/.bin/esbuild src/main.ts --watch --target=es2018 --bundle --outfile=dist/main.mjs --format=esm --drop-labels=DEV,TEST",
     "format": "npx prettier src/ tests/ --write --trailing-comma all",
+    "format:check": "npx prettier src/ tests/ --check --trailing-comma all",
     "start:wasm-quickjs": "wasmer run adamz/quickjs -e quickjs  --mapdir .:. dist/main.test.mjs test",
     "start:quickjs": "qjs dist/main.test.mjs test",
     "start:nodejs": "node dist/main.test.mjs test",


### PR DESCRIPTION
Add a Github workflow which automatically runs the following tasks on any npm project found in the repository:
* `npm test`
* `npm run format:check` (if the task is defined)