### PR TITLE
chore(jsonata-xform): replace lodash with es-toolkit to reduce size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2491,6 +2491,16 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.39.8",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.8.tgz",
+      "integrity": "sha512-A8QO9TfF+rltS8BXpdu8OS+rpGgEdnRhqIVxO/ZmNvnXBYgOdSsxukT55ELyP94gZIntWJ+Li9QRrT2u1Kitpg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.25.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
@@ -3741,12 +3751,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
     },
     "node_modules/log-surge": {
       "resolved": "pipelines/log-surge",
@@ -5002,8 +5006,8 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonata": "^2.0.6",
-        "lodash": "^4.17.21"
+        "es-toolkit": "^1.39.8",
+        "jsonata": "^2.0.6"
       },
       "devDependencies": {
         "@faker-js/faker": "^9.9.0",

--- a/pipelines/jsonata-xform/package.json
+++ b/pipelines/jsonata-xform/package.json
@@ -30,7 +30,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "jsonata": "^2.0.6",
-    "lodash": "^4.17.21"
+    "es-toolkit": "^1.39.8",
+    "jsonata": "^2.0.6"
   }
 }

--- a/pipelines/jsonata-xform/src/dynamicmapper.ts
+++ b/pipelines/jsonata-xform/src/dynamicmapper.ts
@@ -1,6 +1,6 @@
 import { Message } from "../../common/tedge";
 import jsonata from "jsonata";
-import * as _ from "lodash";
+import { set, get, merge, unset, has } from "es-toolkit/compat";
 // https://nearform.com/insights/the-jsonata-performance-dilemma/
 
 export interface Substitution {
@@ -37,25 +37,25 @@ function applyModifiers(src: any, dst: any, paths: PropertyMapping[]): any {
     ...src,
   };
   paths.forEach((path) => {
-    const value = _.get(src, path.source);
+    const value = get(src, path.source);
     applyModifier(value, output, path);
   });
   return output;
 }
 
-function applyModifier(value: any, output: any, path: PropertyMapping): any {
+function applyModifier(value: object, output: any, path: PropertyMapping): any {
   if (path.mode == Mode.IfNotPresent) {
-    if (!_.has(output, path.destination)) {
-      _.set(output, path.destination, value);
+    if (!has(output, path.destination)) {
+      set(output, path.destination, value);
     }
   } else if (path.mode == Mode.IfDefined) {
-    if (!_.isUndefined(value)) {
-      _.set(output, path.destination, value);
+    if (typeof value !== "undefined") {
+      set(output, path.destination, value);
     }
   } else if (path.mode == Mode.Delete) {
-    _.unset(output, path.source);
+    unset(output, path.source);
   } else {
-    _.set(output, path.destination, value);
+    set(output, path.destination, value);
   }
   return output;
 }
@@ -106,7 +106,7 @@ export async function build(
   };
 
   mods.forEach((item) => {
-    output = _.merge(output, item);
+    output = merge(output, item);
   });
   return applyModifiers(output, {}, postModifiers);
 }


### PR DESCRIPTION
Replacing lodash and using a more modern es-toolkit (yet fully compatible with lodash), the bundle size reduced from ~500KB to ~256KB.